### PR TITLE
Create the 'links' table.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: clojure
 sudo: false
 lein: lein2
+script: script/test
 jdk:
   - oraclejdk8
 services:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ## Installation
 
+* Install JDK 1.8: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 * Install Leiningen: http://leiningen.org/
 * Clone the repo
 * Run the app with `lein run`. It will open on `localhost:3000`

--- a/env/dev/resources/config.edn
+++ b/env/dev/resources/config.edn
@@ -8,4 +8,9 @@
            :database "dkdjukeh"
            :username "dkdjukeh"
            :password "V2luMVXaEQfNyDafaRYh0K7o_5X7gvVF"
-           :pool-size 1}}
+           :pool-size 1
+           :classname "com.postgresql.Driver"
+           :subprotocol "postgresql"
+           :user "dkdjukeh"
+           :subname "//horton.elephantsql.com/dkdjukeh"
+           }}

--- a/project.clj
+++ b/project.clj
@@ -25,11 +25,13 @@
                  [luminus-immutant "0.1.9"]
                  [luminus-log4j "0.1.3"]
                  [environ "1.0.2"]
+                 [migratus "0.8.11"]
                  [alaisi/postgres.async "0.6.0"]
                  [postgresql "9.3-1102.jdbc41"]]
 
-
-  :aliases {"autotest" ["test-refresh"]}
+  :aliases {"migrate"  ["run" "-m" "squad-share.migrations/migrate"]
+            "rollback" ["run" "-m" "squad-share.migrations/rollback"]
+            "autotest" ["test-refresh"]}
 
   :min-lein-version "2.0.0"
 

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,8 @@
                  [luminus-immutant "0.1.9"]
                  [luminus-log4j "0.1.3"]
                  [environ "1.0.2"]
-                 [alaisi/postgres.async "0.6.0"]]
+                 [alaisi/postgres.async "0.6.0"]
+                 [postgresql "9.3-1102.jdbc41"]]
 
 
   :aliases {"autotest" ["test-refresh"]}

--- a/resources/migrations/20160418164525-add-links-table.down.sql
+++ b/resources/migrations/20160418164525-add-links-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS squadshare.links;

--- a/resources/migrations/20160418164525-add-links-table.up.sql
+++ b/resources/migrations/20160418164525-add-links-table.up.sql
@@ -1,3 +1,5 @@
+CREATE SCHEMA squadshare;
+
 CREATE TABLE IF NOT EXISTS squadshare.links
 (id INT PRIMARY KEY,
  title VARCHAR(50),

--- a/resources/migrations/20160418164525-add-links-table.up.sql
+++ b/resources/migrations/20160418164525-add-links-table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS squadshare.links
+(id INT PRIMARY KEY,
+ title VARCHAR(50),
+ url VARCHAR(100),
+ description VARCHAR(255),
+ created_at TIMESTAMP);

--- a/script/test
+++ b/script/test
@@ -1,0 +1,2 @@
+lein migrate
+lein test

--- a/src/clj/squad_share/config.clj
+++ b/src/clj/squad_share/config.clj
@@ -6,14 +6,14 @@
 
 (defn get-config
   []
-(load-config
-                       :merge
-                       [(args)
-                        (source/from-system-props)
-                        (source/from-env)]))
+  (load-config
+   :merge
+   [(args)
+    (source/from-system-props)
+    (source/from-env)]))
 
 (defstate env :start (get-config))
 
-(def config (-> (get-config) :pg-conn))
-(def db (pg/open-db config))
+(def dbconfig (-> (get-config) :pg-conn))
+(def db (pg/open-db dbconfig))
 

--- a/src/clj/squad_share/migrations.clj
+++ b/src/clj/squad_share/migrations.clj
@@ -1,0 +1,14 @@
+(ns squad-share.migrations
+  (:require [migratus.core :as migratus]
+            [squad-share.config :as config]))
+
+(def config {:store                :database
+             :migration-dir        "migrations/"
+             :migration-table-name "migrations"
+             :db config/dbconfig})
+
+(defn migrate [& args]
+  (migratus/migrate config))
+
+(defn rollback [& args]
+  (migratus/rollback config))


### PR DESCRIPTION
Why:

* So we can store the links shared.

This change addresses the need by:

* Creating 'up' and 'down' migrations.