### PR TITLE
Trim link title and description.

### DIFF
--- a/resources/public/js/trim.js
+++ b/resources/public/js/trim.js
@@ -1,0 +1,13 @@
+$(document).ready(function() {
+  
+  function trim(klass, size) {
+    $.each($(klass), function() {
+      if (this.innerHTML.length >= size) {
+        this.innerHTML = this.innerHTML.substring(0, size) +  "...";
+      }
+    });
+  }
+
+  trim(".link-title", 25);
+  trim(".description", 60);
+});

--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <META name="viewport" content="width=device-width, initial-scale=1">
-    <title>Squad Share</title>
+    <title>SquadShare</title>
     <link rel='' type='image/x-icon' href='/favicon.ico' />
 
     <!-- styles -->
@@ -43,10 +43,12 @@
     {% script "/assets/tether/dist/js/tether.min.js" %}
     {% script "/assets/bootstrap/js/bootstrap.min.js" %}
     {% script "/js/floatLabel.js" %}
+    {% script "/js/trim.js" %}
 
     <script type="text/javascript">
       var context = "{{servlet-context}}";
     </script>
+    
     {% block page-scripts %}
     {% endblock %}
   </body>

--- a/resources/templates/links.html
+++ b/resources/templates/links.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 
-
 <div class="row"> 
   <div class="col-md-12 ss-search">
     <h2 class="ss-search__title">Search Links</h2>
@@ -14,7 +13,6 @@
     </ul>
   </div>
 </div>
-
 
 <div class="row"> 
   <div class="container ss-links-wrapper">
@@ -29,7 +27,6 @@
       </figure>
     </div>
     
-    
     <!--   Link Module -->
     {% for link in links %} 
     <div class="col-lg-3 col-md-6 col-sm-6 col-xs-12 ss-link-module">
@@ -39,7 +36,7 @@
           
           <img class="thumbnail" src="images/img_default.svg" alt="{{link.title}}">
           <figcaption>
-            <h3>{{link.title}}</h3>
+            <h3 class="link-title">{{link.title}}</h3>
             <p class="description">{{link.description}}</p>
           </figcaption> 
           
@@ -64,10 +61,10 @@
 
     </div>
     {% endfor %}
-    <!--  End Link Module -->
+    <!-- End Link Module -->
 
-  </div><!--   End ss-links-wrapper -->
-</div><!--   End Row -->
+  </div><!-- End ss-links-wrapper -->
+</div><!-- End Row -->
 
 </div>
 {% endblock %}

--- a/src/clj/squad_share/interactors/list_links.clj
+++ b/src/clj/squad_share/interactors/list_links.clj
@@ -6,7 +6,7 @@
 
 (defn run!
   [context]
-  (let [ result (<!! (pg/execute! config/db ["select title, url, description from squadshare.links"])) ]
+  (let [ result (<!! (pg/execute! config/db ["select title, url, description from squadshare.links order by created_at desc"])) ]
     (prn result)
     (result :rows)
   )


### PR DESCRIPTION
Why:

* Because it's a small area and everything can't be visible.

This change addresses the need by:

* Adding (...) at the end of long titles and descriptions with a javascript function.